### PR TITLE
vec2: change interface to have distinct out and const in params

### DIFF
--- a/glug_math/include/glug/math/vec2.h
+++ b/glug_math/include/glug/math/vec2.h
@@ -5,42 +5,45 @@
 #include <glug/import.h>
 #include <glug/bool_t.h>
 
-#include <glug/math/vec2_t.h>
-
 GLUG_EXTERN_START
+
+struct glug_vec2;
+
+GLUG_LIB_API float glug_vec2_x(const struct glug_vec2 *v);
+GLUG_LIB_API float glug_vec2_y(const struct glug_vec2 *v);
 
 GLUG_LIB_API glug_bool_t glug_vec2_equal(const struct glug_vec2 *v1, const struct glug_vec2 *v2);
 
-GLUG_LIB_API void glug_vec2_add(struct glug_vec2 *dst, const struct glug_vec2 *v2);
-GLUG_LIB_API void glug_vec2_sub(struct glug_vec2 *dst, const struct glug_vec2 *v2);
-GLUG_LIB_API void glug_vec2_mul(struct glug_vec2 *dst, float scalar);
-GLUG_LIB_API void glug_vec2_div(struct glug_vec2 *dst, float scalar);
-GLUG_LIB_API void glug_vec2_mul_cw(struct glug_vec2 *dst, const struct glug_vec2 *v, const struct glug_vec2 *v2);
-GLUG_LIB_API void glug_vec2_div_cw(struct glug_vec2 *dst, const struct glug_vec2 *v, const struct glug_vec2 *v2);
+GLUG_LIB_API struct glug_vec2 *glug_vec2_add(struct glug_vec2 *dst, const struct glug_vec2 *v1, const struct glug_vec2 *v2);
+GLUG_LIB_API struct glug_vec2 *glug_vec2_sub(struct glug_vec2 *dst, const struct glug_vec2 *v1, const struct glug_vec2 *v2);
+GLUG_LIB_API struct glug_vec2 *glug_vec2_mul(struct glug_vec2 *dst, const struct glug_vec2 *v, float scalar);
+GLUG_LIB_API struct glug_vec2 *glug_vec2_div(struct glug_vec2 *dst, const struct glug_vec2 *v, float scalar);
+GLUG_LIB_API struct glug_vec2 *glug_vec2_mul_cw(struct glug_vec2 *dst, const struct glug_vec2 *v, const struct glug_vec2 *v2);
+GLUG_LIB_API struct glug_vec2 *glug_vec2_div_cw(struct glug_vec2 *dst, const struct glug_vec2 *v, const struct glug_vec2 *v2);
 
-GLUG_LIB_API void glug_vec2_sign(struct glug_vec2 *dst, const struct glug_vec2 *v);
-GLUG_LIB_API void glug_vec2_integral(struct glug_vec2 *dst, const struct glug_vec2 *v);
-GLUG_LIB_API void glug_vec2_frac(struct glug_vec2 *dst, const struct glug_vec2 *v);
+GLUG_LIB_API struct glug_vec2 *glug_vec2_sign(struct glug_vec2 *dst, const struct glug_vec2 *v);
+GLUG_LIB_API struct glug_vec2 *glug_vec2_integral(struct glug_vec2 *dst, const struct glug_vec2 *v);
+GLUG_LIB_API struct glug_vec2 *glug_vec2_frac(struct glug_vec2 *dst, const struct glug_vec2 *v);
 
-GLUG_LIB_API void glug_vec2_max(struct glug_vec2 *dst, const struct glug_vec2 *v2);
-GLUG_LIB_API void glug_vec2_min(struct glug_vec2 *dst, const struct glug_vec2 *v2);
-GLUG_LIB_API void glug_vec2_clamp(struct glug_vec2 *dst, const struct glug_vec2 *min, const struct glug_vec2 *max);
+GLUG_LIB_API struct glug_vec2 *glug_vec2_max(struct glug_vec2 *dst, const struct glug_vec2 *v1, const struct glug_vec2 *v2);
+GLUG_LIB_API struct glug_vec2 *glug_vec2_min(struct glug_vec2 *dst, const struct glug_vec2 *v1, const struct glug_vec2 *v2);
+GLUG_LIB_API struct glug_vec2 *glug_vec2_clamp(struct glug_vec2 *dst, const struct glug_vec2 *v, const struct glug_vec2 *min, const struct glug_vec2 *max);
 
-GLUG_LIB_API void glug_vec2_floor(struct glug_vec2 *dst, const struct glug_vec2 *v);
-GLUG_LIB_API void glug_vec2_ceil(struct glug_vec2 *dst, const struct glug_vec2 *v);
-GLUG_LIB_API void glug_vec2_round(struct glug_vec2 *dst, const struct glug_vec2 *v);
-GLUG_LIB_API void glug_vec2_round_zero(struct glug_vec2 *dst, const struct glug_vec2 *v);
+GLUG_LIB_API struct glug_vec2 *glug_vec2_floor(struct glug_vec2 *dst, const struct glug_vec2 *v);
+GLUG_LIB_API struct glug_vec2 *glug_vec2_ceil(struct glug_vec2 *dst, const struct glug_vec2 *v);
+GLUG_LIB_API struct glug_vec2 *glug_vec2_round(struct glug_vec2 *dst, const struct glug_vec2 *v);
+GLUG_LIB_API struct glug_vec2 *glug_vec2_round_zero(struct glug_vec2 *dst, const struct glug_vec2 *v);
 
 GLUG_LIB_API float glug_vec2_dot(const struct glug_vec2 *v1, const struct glug_vec2 *v2);
 
 GLUG_LIB_API float glug_vec2_len(const struct glug_vec2 *v);
 GLUG_LIB_API float glug_vec2_len_squared(const struct glug_vec2 *v);
 GLUG_LIB_API float glug_vec2_len_taxi(const struct glug_vec2 *v);
-GLUG_LIB_API void  glug_vec2_set_len(struct glug_vec2 *v, float length);
-GLUG_LIB_API void  glug_vec2_clamp_len(struct glug_vec2 *v, float min, float max);
+GLUG_LIB_API struct glug_vec2 *glug_vec2_set_len(struct glug_vec2 *dst, const struct glug_vec2 *v, float length);
+GLUG_LIB_API struct glug_vec2 *glug_vec2_clamp_len(struct glug_vec2 *dst, const struct glug_vec2 *v, float min, float max);
 
 GLUG_LIB_API glug_bool_t glug_vec2_is_normal(const struct glug_vec2 *v);
-GLUG_LIB_API void  glug_vec2_normalize(struct glug_vec2 *v);
+GLUG_LIB_API struct glug_vec2 *glug_vec2_normalize(struct glug_vec2 *dst, const struct glug_vec2 *v);
 
 GLUG_LIB_API float glug_vec2_dist(const struct glug_vec2 *v1, const struct glug_vec2 *v2);
 GLUG_LIB_API float glug_vec2_dist_squared(const struct glug_vec2 *v1, const struct glug_vec2 *v2);
@@ -48,10 +51,10 @@ GLUG_LIB_API float glug_vec2_dist_taxi(const struct glug_vec2 *v1, const struct 
 
 GLUG_LIB_API float glug_vec2_angle_btw(const struct glug_vec2 *v1, const struct glug_vec2 *v2);
 
-GLUG_LIB_API void glug_vec2_project(struct glug_vec2 *dst, const struct glug_vec2 *v2);
-GLUG_LIB_API void glug_vec2_reject(struct glug_vec2 *dst, const struct glug_vec2 *v2);
-GLUG_LIB_API void glug_vec2_reflect(struct glug_vec2 *dst, const struct glug_vec2 *v2);
-GLUG_LIB_API void glug_vec2_refract(struct glug_vec2 *dst, const struct glug_vec2 *n, float incidx, float tranidx);
+GLUG_LIB_API struct glug_vec2 *glug_vec2_project(struct glug_vec2 *dst, const struct glug_vec2 *v, const struct glug_vec2 *onto);
+GLUG_LIB_API struct glug_vec2 *glug_vec2_reject(struct glug_vec2 *dst, const struct glug_vec2 *v, const struct glug_vec2 *from);
+GLUG_LIB_API struct glug_vec2 *glug_vec2_reflect(struct glug_vec2 *dst, const struct glug_vec2 *v, const struct glug_vec2 *about);
+GLUG_LIB_API struct glug_vec2 *glug_vec2_refract(struct glug_vec2 *dst, const struct glug_vec2 *v, const struct glug_vec2 *n, float idx_ratio);
 
 GLUG_EXTERN_END
 

--- a/glug_math/src/vec2.c
+++ b/glug_math/src/vec2.c
@@ -1,142 +1,162 @@
+#include <glug/math/vec2_t.h>
 #include <glug/math/vec2.h>
 #include <glug/math/float.h>
 
 #include <math.h>
+
+float glug_vec2_x(const struct glug_vec2 *v)
+{
+    return v->x;
+}
+
+float glug_vec2_y(const struct glug_vec2 *v)
+{
+    return v->y;
+}
 
 glug_bool_t glug_vec2_equal(const struct glug_vec2 *v1, const struct glug_vec2 *v2)
 {
 
 }
 
-void glug_vec2_add(struct glug_vec2 *dst, const struct glug_vec2 *v2)
+struct glug_vec2 *glug_vec2_add(struct glug_vec2 *dst, const struct glug_vec2 *v1, const struct glug_vec2 *v2)
 {
-    struct glug_vec2 res = *dst;
-    res.x += v2->x;
-    res.y += v2->y;
+    *dst = (struct glug_vec2){
+        .x = v1->x + v2->x,
+        .y = v1->y + v2->y,
+    };
 
-    *dst = res;
+    return dst;
 }
 
-void glug_vec2_sub(struct glug_vec2 *dst, const struct glug_vec2 *v2)
+struct glug_vec2 *glug_vec2_sub(struct glug_vec2 *dst, const struct glug_vec2 *v1, const struct glug_vec2 *v2)
 {
-    struct glug_vec2 res = *dst;
-    res.x -= v2->x;
-    res.y -= v2->y;
+    *dst = (struct glug_vec2){
+        .x = v1->x - v2->x,
+        .y = v1->y - v2->y,
+    };
 
-    *dst = res;
+    return dst;
 }
 
-void glug_vec2_mul(struct glug_vec2 *dst, float scalar)
+struct glug_vec2 *glug_vec2_mul(struct glug_vec2 *dst, const struct glug_vec2 *v, float scalar)
 {
-    struct glug_vec2 res = *dst;
-    res.x *= scalar;
-    res.y *= scalar;
+    *dst = (struct glug_vec2){
+        .x = v->x * scalar,
+        .y = v->y * scalar,
+    };
 
-    *dst = res;
+    return dst;
 }
 
-void glug_vec2_div(struct glug_vec2 *dst, float scalar)
+struct glug_vec2 *glug_vec2_div(struct glug_vec2 *dst, const struct glug_vec2 *v, float scalar)
 {
-    glug_vec2_mul(dst, 1.f / scalar);
+    return glug_vec2_mul(dst, v, 1.f / scalar);
 }
 
-void glug_vec2_mul_cw(struct glug_vec2 *dst, const struct glug_vec2 *v, const struct glug_vec2 *v2)
+struct glug_vec2 *glug_vec2_mul_cw(struct glug_vec2 *dst, const struct glug_vec2 *v, const struct glug_vec2 *v2)
 {
     *dst = (struct glug_vec2){
         .x = v->x * v2->x,
         .y = v->y * v2->y,
     };
+    return dst;
 }
 
-void glug_vec2_div_cw(struct glug_vec2 *dst, const struct glug_vec2 *v, const struct glug_vec2 *v2)
+struct glug_vec2 *glug_vec2_div_cw(struct glug_vec2 *dst, const struct glug_vec2 *v, const struct glug_vec2 *v2)
 {
     *dst = (struct glug_vec2){
         .x = v->x / v2->x,
         .y = v->y / v2->y,
     };
+    return dst;
 }
 
-void glug_vec2_sign(struct glug_vec2 *dst, const struct glug_vec2 *v)
+struct glug_vec2 *glug_vec2_sign(struct glug_vec2 *dst, const struct glug_vec2 *v)
 {
     *dst = (struct glug_vec2){
         .x = glug_float_sign(v->x),
         .y = glug_float_sign(v->y),
     };
+    return dst;
 }
 
-void glug_vec2_integral(struct glug_vec2 *dst, const struct glug_vec2 *v)
+struct glug_vec2 *glug_vec2_integral(struct glug_vec2 *dst, const struct glug_vec2 *v)
 {
     *dst = (struct glug_vec2){
         .x = glug_float_integral(v->x),
         .y = glug_float_integral(v->y),
     };
+    return dst;
 }
 
-void glug_vec2_frac(struct glug_vec2 *dst, const struct glug_vec2 *v)
+struct glug_vec2 *glug_vec2_frac(struct glug_vec2 *dst, const struct glug_vec2 *v)
 {
     *dst = (struct glug_vec2){
         .x = glug_float_frac(v->x),
         .y = glug_float_frac(v->y),
     };
+    return dst;
 }
 
-void glug_vec2_max(struct glug_vec2 *dst, const struct glug_vec2 *v2)
+struct glug_vec2 *glug_vec2_max(struct glug_vec2 *dst, const struct glug_vec2 *v1, const struct glug_vec2 *v2)
 {
-    struct glug_vec2 res = *dst;
-    res.x = glug_float_max(dst->x, v2->x);
-    res.y = glug_float_max(dst->y, v2->y);
-
-    *dst = res;
+    *dst = (struct glug_vec2){
+        .x = glug_float_max(v1->x, v2->x),
+        .y = glug_float_max(v1->y, v2->y),
+    };
+    return dst;
 }
 
-void glug_vec2_min(struct glug_vec2 *dst, const struct glug_vec2 *v2)
+struct glug_vec2 *glug_vec2_min(struct glug_vec2 *dst, const struct glug_vec2 *v1, const struct glug_vec2 *v2)
 {
-    struct glug_vec2 res = *dst;
-    res.x = glug_float_min(dst->x, v2->x);
-    res.y = glug_float_min(dst->y, v2->y);
-
-    *dst = res;
+    *dst = (struct glug_vec2){
+        .x = glug_float_min(v1->x, v2->x),
+        .y = glug_float_min(v1->y, v2->y),
+    };
+    return dst;
 }
 
-void glug_vec2_clamp(struct glug_vec2 *dst, const struct glug_vec2 *min, const struct glug_vec2 *max)
+struct glug_vec2 *glug_vec2_clamp(struct glug_vec2 *dst, const struct glug_vec2 *v, const struct glug_vec2 *min, const struct glug_vec2 *max)
 {
-    struct glug_vec2 res = *dst;
-    glug_vec2_max(&res, min);
-    glug_vec2_min(&res, max);
-
-    *dst = res;
+    struct glug_vec2 tmp_max;
+    return glug_vec2_min(dst, max, glug_vec2_max(&tmp_max, v, min));
 }
 
-void glug_vec2_floor(struct glug_vec2 *dst, const struct glug_vec2 *v)
+struct glug_vec2 *glug_vec2_floor(struct glug_vec2 *dst, const struct glug_vec2 *v)
 {
     *dst = (struct glug_vec2){
         .x = glug_float_floor(v->x),
         .y = glug_float_floor(v->y),
     };
+    return dst;
 }
 
-void glug_vec2_ceil(struct glug_vec2 *dst, const struct glug_vec2 *v)
+struct glug_vec2 *glug_vec2_ceil(struct glug_vec2 *dst, const struct glug_vec2 *v)
 {
     *dst = (struct glug_vec2){
         .x = glug_float_ceil(v->x),
         .y = glug_float_ceil(v->y),
     };
+    return dst;
 }
 
-void glug_vec2_round(struct glug_vec2 *dst, const struct glug_vec2 *v)
+struct glug_vec2 *glug_vec2_round(struct glug_vec2 *dst, const struct glug_vec2 *v)
 {
     *dst = (struct glug_vec2){
         .x = glug_float_round(v->x),
         .y = glug_float_round(v->y),
     };
+    return dst;
 }
 
-void glug_vec2_round_zero(struct glug_vec2 *dst, const struct glug_vec2 *v)
+struct glug_vec2 *glug_vec2_round_zero(struct glug_vec2 *dst, const struct glug_vec2 *v)
 {
     *dst = (struct glug_vec2){
         .x = glug_float_round_zero(v->x),
         .y = glug_float_round_zero(v->y),
     };
+    return dst;
 }
 
 float glug_vec2_dot(const struct glug_vec2 *v1, const struct glug_vec2 *v2)
@@ -159,17 +179,14 @@ float glug_vec2_len_taxi(const struct glug_vec2 *v)
     return fabsf(v->x) + fabsf(v->y);
 }
 
-void glug_vec2_set_len(struct glug_vec2 *v, float length)
+struct glug_vec2 *glug_vec2_set_len(struct glug_vec2 *dst, const struct glug_vec2 *v, float length)
 {
-    glug_vec2_mul(v, length / glug_vec2_len(v));
+    return glug_vec2_mul(dst, v, length / glug_vec2_len(v));
 }
 
-void glug_vec2_clamp_len(struct glug_vec2 *v, float min, float max)
+struct glug_vec2 *glug_vec2_clamp_len(struct glug_vec2 *dst, const struct glug_vec2 *v, float min, float max)
 {
-    float l = glug_vec2_len(v);
-    float clamped = glug_float_clamp(l, min, max);
-
-    glug_vec2_mul(v, clamped / l);
+    return glug_vec2_set_len(dst, v, glug_float_clamp(glug_vec2_len(v), min, max));
 }
 
 glug_bool_t glug_vec2_is_normal(const struct glug_vec2 *v)
@@ -177,9 +194,9 @@ glug_bool_t glug_vec2_is_normal(const struct glug_vec2 *v)
 
 }
 
-void glug_vec2_normalize(struct glug_vec2 *v)
+struct glug_vec2 *glug_vec2_normalize(struct glug_vec2 *dst, const struct glug_vec2 *v)
 {
-    glug_vec2_div(v, glug_vec2_len(v));
+    return glug_vec2_div(dst, v, glug_vec2_len(v));
 }
 
 float glug_vec2_dist(const struct glug_vec2 *v1, const struct glug_vec2 *v2)
@@ -205,53 +222,47 @@ float glug_vec2_dist_taxi(const struct glug_vec2 *v1, const struct glug_vec2 *v2
 
 float glug_vec2_angle_btw(const struct glug_vec2 *v1, const struct glug_vec2 *v2)
 {
-    return acosf(glug_vec2_dot(v1, v2) / glug_vec2_len(v1) / glug_vec2_len(v2));
+    float dot = glug_vec2_dot(v1, v2);
+    float l1 = glug_vec2_len(v1);
+    float l2 = glug_vec2_len(v2);
+    return acosf(dot / l1 / l2);
 }
 
-void glug_vec2_project(struct glug_vec2 *dst, const struct glug_vec2 *v2)
+struct glug_vec2 *glug_vec2_project(struct glug_vec2 *dst, const struct glug_vec2 *v, const struct glug_vec2 *onto)
 {
-    struct glug_vec2 res = *v2;
-    glug_vec2_normalize(&res);
-    float proj_len = glug_vec2_dot(dst, &res);
-    glug_vec2_mul(&res, proj_len);
-
-    *dst = res;
+    struct glug_vec2 normal;
+    glug_vec2_normalize(&normal, onto);
+    float proj_len = glug_vec2_dot(v, &normal);
+    return glug_vec2_mul(dst, &normal, proj_len);
 }
 
-void glug_vec2_reject(struct glug_vec2 *dst, const struct glug_vec2 *v2)
+struct glug_vec2 *glug_vec2_reject(struct glug_vec2 *dst, const struct glug_vec2 *v, const struct glug_vec2 *from)
 {
-    struct glug_vec2 res = *dst, proj = *dst;
-    glug_vec2_project(&proj, v2);
-    glug_vec2_sub(&res, &proj);
-
-    *dst = res;
+    struct glug_vec2 proj;
+    return glug_vec2_sub(dst, v, glug_vec2_project(&proj, v, from));
 }
 
-void glug_vec2_reflect(struct glug_vec2 *dst, const struct glug_vec2 *v2)
+struct glug_vec2 *glug_vec2_reflect(struct glug_vec2 *dst, const struct glug_vec2 *v, const struct glug_vec2 *about)
 {
-    struct glug_vec2 res = *dst, rej = *dst;
-    glug_vec2_reject(&rej, v2);
-    glug_vec2_sub(&res, &rej);
-    glug_vec2_sub(&res, &rej);
-
-    *dst = res;
+    struct glug_vec2 rej;
+    return glug_vec2_sub(dst, v, glug_vec2_mul(&rej, glug_vec2_reject(&rej, v, about), 2.f));
 }
 
-void glug_vec2_refract(struct glug_vec2 *dst, const struct glug_vec2 *n, float incidx, float tranidx)
+struct glug_vec2 *glug_vec2_refract(struct glug_vec2 *dst, const struct glug_vec2 *v, const struct glug_vec2 *n, float idx_ratio)
 {
-    // (ni/nt * N.I - sqrt(1 - (ni/nt)^2 * (1 - N.I * N.I)) * N - ni/nt * I
-    float incproj, idxratio = incidx / tranidx;
-    float dstlen = glug_vec2_len(dst);
-    struct glug_vec2 norm = *n, inc = *dst;
-    glug_vec2_normalize(&norm);
-    glug_vec2_normalize(&inc);
-    glug_vec2_mul(&inc, -1);
+    float v_len = glug_vec2_len(v);
+    float n_len = glug_vec2_len(n);
+    float dst_len = v_len * idx_ratio;
 
-    incproj = glug_vec2_dot(&inc, &norm);
-    glug_vec2_mul(&inc, idxratio);
+    struct glug_vec2 dst_proj, dst_rej;
+    glug_vec2_sub(&dst_rej, v, glug_vec2_project(&dst_proj, v, n));
 
-    *dst = norm;
-    glug_vec2_mul(dst, -sqrtf(1 - idxratio * idxratio * (1 - incproj * incproj)) + idxratio * incproj);
-    glug_vec2_sub(dst, &inc);
-    glug_vec2_mul(dst, dstlen);
+    float inc_cosangle = -glug_vec2_dot(v, n) / v_len / n_len;
+    float rej_len = sqrtf(1 - inc_cosangle * inc_cosangle) * idx_ratio * dst_len;
+    glug_vec2_set_len(&dst_rej, &dst_rej, rej_len);
+
+    float proj_len = sqrtf(dst_len * dst_len - rej_len * rej_len);
+    glug_vec2_set_len(&dst_proj, &dst_proj, proj_len);
+
+    return glug_vec2_add(dst, &dst_proj, &dst_rej);
 }

--- a/glug_math/tests/suites/vec2.c
+++ b/glug_math/tests/suites/vec2.c
@@ -13,173 +13,183 @@ static void test_equal(void)
 
 static void test_add(void)
 {
-    struct glug_vec2 dst = { 1.f, 8.9f };
+    struct glug_vec2 dst;
+    struct glug_vec2 v1 = { 1.f, 8.9f };
     struct glug_vec2 v2 = { -1.01f, -5.5f };
     struct glug_vec2 exp = { -0.01f, 3.4f };
 
-    glug_vec2_add(&dst, &v2);
+    glug_vec2_add(&dst, &v1, &v2);
     ASSERT_VEC2_EQUAL(&dst, &exp, 0.001f);
 }
 
 static void test_sub(void)
 {
-    struct glug_vec2 dst = { 17.17f, 19.8f };
+    struct glug_vec2 dst;
+    struct glug_vec2 v1 = { 17.17f, 19.8f };
     struct glug_vec2 v2 = { 8.f, 9.f };
     struct glug_vec2 exp = { 9.17f, 10.8f };
 
-    glug_vec2_sub(&dst, &v2);
+    glug_vec2_sub(&dst, &v1, &v2);
     ASSERT_VEC2_EQUAL(&dst, &exp, 0.001f);
 }
 
 static void test_mul(void)
 {
-    struct glug_vec2 dst = { 4.f, 5.f };
+    struct glug_vec2 dst;
+    struct glug_vec2 v1 = { 4.f, 5.f };
     float scalar = 4.1f;
     struct glug_vec2 exp = { 16.4f, 20.5f };
 
-    glug_vec2_mul(&dst, scalar);
+    glug_vec2_mul(&dst, &v1, scalar);
     ASSERT_VEC2_EQUAL(&dst, &exp, 0.01f);
 }
 
 static void test_div(void)
 {
-    struct glug_vec2 dst = { 3.142f, 2.718f };
+    struct glug_vec2 dst;
+    struct glug_vec2 v = { 3.142f, 2.718f };
     float scalar = 1.414f;
     struct glug_vec2 exp = { 2.222065f, 1.922206f };
 
-    glug_vec2_div(&dst, scalar);
+    glug_vec2_div(&dst, &v, scalar);
     ASSERT_VEC2_EQUAL(&dst, &exp, 0.000001f);
 }
 
 static void test_mul_cw(void)
 {
+    struct glug_vec2 dst;
     struct glug_vec2 v1 = { 1.5f, 2.f };
     struct glug_vec2 v2 = { 2.f, 1.f };
-    struct glug_vec2 exp;
+    struct glug_vec2 exp = { 3.f, 2.f };
 
-    glug_vec2_mul_cw(&v1, &v1, &v2);
-    exp = (struct glug_vec2){ 3.f, 2.f };
-    ASSERT_VEC2_EQUAL(&v1, &exp, 0.0001f);
+    glug_vec2_mul_cw(&dst, &v1, &v2);
+    ASSERT_VEC2_EQUAL(&dst, &exp, 0.0001f);
 }
 
 static void test_div_cw(void)
 {
+    struct glug_vec2 dst;
     struct glug_vec2 v1 = { 3.f, 2.f };
     struct glug_vec2 v2 = { 1.5f, 1.f };
-    struct glug_vec2 exp;
+    struct glug_vec2 exp = { 2.f, 2.f };
 
-    glug_vec2_div_cw(&v1, &v1, &v2);
-    exp = (struct glug_vec2){ 2.f, 2.f };
-    ASSERT_VEC2_EQUAL(&v1, &exp, 0.0001f);
+    glug_vec2_div_cw(&dst, &v1, &v2);
+    ASSERT_VEC2_EQUAL(&dst, &exp, 0.0001f);
 }
 
 static void test_sign(void)
 {
-    struct glug_vec2 dst = { -13.7123f, 5.2972f };
+    struct glug_vec2 dst;
+    struct glug_vec2 v = { -13.7123f, 5.2972f };
     struct glug_vec2 exp = { -1.f, 1.f };
 
-    glug_vec2_sign(&dst, &dst);
+    glug_vec2_sign(&dst, &v);
     ASSERT_VEC2_EQUAL(&dst, &exp, 0.f);
 
-    dst.x = 0.f;
+    v.x = 0.f;
     exp.x = 0.f;
 
-    glug_vec2_sign(&dst, &dst);
+    glug_vec2_sign(&dst, &v);
     ASSERT_VEC2_EQUAL(&dst, &exp, 0.f);
 }
 
 static void test_integral(void)
 {
-    struct glug_vec2 dst = { -13.7123f, 5.2972f };
+    struct glug_vec2 dst;
+    struct glug_vec2 v = { -13.7123f, 5.2972f };
     struct glug_vec2 exp = { -13.f, 5.f };
 
-    glug_vec2_integral(&dst, &dst);
+    glug_vec2_integral(&dst, &v);
     ASSERT_VEC2_EQUAL(&dst, &exp, 0.f);
 }
 
 static void test_frac(void)
 {
-    struct glug_vec2 dst = { -13.7123f, 5.2972f };
+    struct glug_vec2 dst;
+    struct glug_vec2 v = { -13.7123f, 5.2972f };
     struct glug_vec2 exp = { -0.7123f,  0.2972f };
 
-    glug_vec2_frac(&dst, &dst);
+    glug_vec2_frac(&dst, &v);
     ASSERT_VEC2_EQUAL(&dst, &exp, 0.00001f);
 }
 
 static void test_max(void)
 {
+    struct glug_vec2 dst;
     struct glug_vec2 v1 = { -2.f, 2.f };
     struct glug_vec2 v2 = { 1.f, -1.f };
-    struct glug_vec2 dst = v1;
     struct glug_vec2 exp = { 1.f, 2.f };
 
-    glug_vec2_max(&dst, &v2);
+    glug_vec2_max(&dst, &v1, &v2);
     ASSERT_VEC2_EQUAL(&dst, &exp, 0.f);
 
-    dst = v2;
-    glug_vec2_max(&dst, &v1);
+    glug_vec2_max(&dst, &v2, &v1);
     ASSERT_VEC2_EQUAL(&dst, &exp, 0.f);
 }
 
 static void test_min(void)
 {
+    struct glug_vec2 dst;
     struct glug_vec2 v1 = { -2.f, 2.f };
     struct glug_vec2 v2 = { 1.f, -1.f };
-    struct glug_vec2 dst = v1;
     struct glug_vec2 exp = { -2.f, -1.f };
 
-    glug_vec2_min(&dst, &v2);
+    glug_vec2_min(&dst, &v1, &v2);
     ASSERT_VEC2_EQUAL(&dst, &exp, 0.f);
 
-    dst = v2;
-    glug_vec2_min(&dst, &v1);
+    glug_vec2_min(&dst, &v2, &v1);
     ASSERT_VEC2_EQUAL(&dst, &exp, 0.f);
 }
 
 static void test_clamp(void)
 {
-    struct glug_vec2 dst = { -2.f, 2.f };
+    struct glug_vec2 dst;
+    struct glug_vec2 v = { -2.f, 2.f };
     struct glug_vec2 min = { -1.f, -1.f };
     struct glug_vec2 max = { 1.f, 1.f };
     struct glug_vec2 exp = { -1.f, 1.f };
 
-    glug_vec2_clamp(&dst, &min, &max);
+    glug_vec2_clamp(&dst, &v, &min, &max);
     ASSERT_VEC2_EQUAL(&dst, &exp, 0.f);
 }
 
 static void test_floor(void)
 {
-    struct glug_vec2 dst = { -13.7123f, 5.2972f };
+    struct glug_vec2 dst;
+    struct glug_vec2 v = { -13.7123f, 5.2972f };
     struct glug_vec2 exp = { -14.f, 5.f };
 
-    glug_vec2_floor(&dst, &dst);
+    glug_vec2_floor(&dst, &v);
     ASSERT_VEC2_EQUAL(&dst, &exp, 0.f);
 }
 
 static void test_ceil(void)
 {
-    struct glug_vec2 dst = { -13.7123f, 5.2972f };
+    struct glug_vec2 dst;
+    struct glug_vec2 v = { -13.7123f, 5.2972f };
     struct glug_vec2 exp = { -13.f, 6.f };
 
-    glug_vec2_ceil(&dst, &dst);
+    glug_vec2_ceil(&dst, &v);
     ASSERT_VEC2_EQUAL(&dst, &exp, 0.00001f);
 }
 
 static void test_round(void)
 {
-    struct glug_vec2 dst = { -13.7123f, 5.2972f };
+    struct glug_vec2 dst;
+    struct glug_vec2 v = { -13.7123f, 5.2972f };
     struct glug_vec2 exp = { -14.f, 5.f };
 
-    glug_vec2_round(&dst, &dst);
+    glug_vec2_round(&dst, &v);
     ASSERT_VEC2_EQUAL(&dst, &exp, 0.00001f);
 }
 
 static void test_round_zero(void)
 {
-    struct glug_vec2 dst = { -13.7123f, 5.2972f };
+    struct glug_vec2 dst;
+    struct glug_vec2 v = { -13.7123f, 5.2972f };
     struct glug_vec2 exp = { -13.f, 5.f };
 
-    glug_vec2_round_zero(&dst, &dst);
+    glug_vec2_round_zero(&dst, &v);
     ASSERT_VEC2_EQUAL(&dst, &exp, 0.00001f);
 }
 
@@ -238,7 +248,7 @@ static void test_set_len(void)
     float newlen = 2.3f;
     struct glug_vec2 exp = { 1.436f, -1.795f };
 
-    glug_vec2_set_len(&v, newlen);
+    glug_vec2_set_len(&v, &v, newlen);
     ASSERT_VEC2_EQUAL(&v, &exp, 0.001f);
 }
 
@@ -246,13 +256,13 @@ static void test_clamp_len(void)
 {
     struct glug_vec2 v = { 2.f, -2.f };
 
-    glug_vec2_clamp_len(&v, 1.f, 5.f);
+    glug_vec2_clamp_len(&v, &v, 1.f, 5.f);
     CU_ASSERT_DOUBLE_EQUAL(glug_vec2_len(&v), sqrtf(8.f), 0.0001f);
 
-    glug_vec2_clamp_len(&v, 1.f, 2.f);
+    glug_vec2_clamp_len(&v, &v, 1.f, 2.f);
     CU_ASSERT_DOUBLE_EQUAL(glug_vec2_len(&v), 2.f, 0.0001f);
 
-    glug_vec2_clamp_len(&v, 5.f, 10.f);
+    glug_vec2_clamp_len(&v, &v, 5.f, 10.f);
     CU_ASSERT_DOUBLE_EQUAL(glug_vec2_len(&v), 5.f, 0.0001f);
 }
 
@@ -263,10 +273,11 @@ static void test_is_norm(void)
 
 static void test_normalize(void)
 {
-    struct glug_vec2 dst = { 3.f, 3.f };
+    struct glug_vec2 dst;
+    struct glug_vec2 v = { 3.f, 3.f };
     struct glug_vec2 exp = { 0.7071f, 0.7071f };
 
-    glug_vec2_normalize(&dst);
+    glug_vec2_normalize(&dst, &v);
     CU_ASSERT_DOUBLE_EQUAL(glug_vec2_len(&dst), 1.f, 0.0001f);
     ASSERT_VEC2_EQUAL(&dst, &exp, 0.00001f);
 }
@@ -301,7 +312,7 @@ static void test_dist_taxi(void)
     CU_ASSERT_DOUBLE_EQUAL(dist, exp, 0.0001f);
 }
 
-static void test_angle_to(void)
+static void test_angle_btw(void)
 {
     struct glug_vec2 a = { -1.0f, 0.f };
     struct glug_vec2 b = { 0.f, 1.f };
@@ -313,41 +324,45 @@ static void test_angle_to(void)
 
 static void test_project(void)
 {
-    struct glug_vec2 dst = { 3.f, 3.f };
-    struct glug_vec2 b = { 1.f, -2.f };
+    struct glug_vec2 dst;
+    struct glug_vec2 v = { 3.f, 3.f };
+    struct glug_vec2 onto = { 1.f, -2.f };
     struct glug_vec2 exp = { -0.6f, 1.2f };
 
-    glug_vec2_project(&dst, &b);
+    glug_vec2_project(&dst, &v, &onto);
     ASSERT_VEC2_EQUAL(&dst, &exp, 0.00001f);
 }
 
 static void test_reject(void)
 {
-    struct glug_vec2 dst = { 3.f, 3.f };
-    struct glug_vec2 b = { 1.f, -2.f };
+    struct glug_vec2 dst;
+    struct glug_vec2 v = { 3.f, 3.f };
+    struct glug_vec2 from = { 1.f, -2.f };
     struct glug_vec2 exp = { 3.6f, 1.8f };
 
-    glug_vec2_reject(&dst, &b);
+    glug_vec2_reject(&dst, &v, &from);
     ASSERT_VEC2_EQUAL(&dst, &exp, 0.00001f);
 }
 
 static void test_reflect(void)
 {
-    struct glug_vec2 dst = { 3.f, 3.f };
-    struct glug_vec2 b = { 1.f, -2.f };
+    struct glug_vec2 dst;
+    struct glug_vec2 v = { 3.f, 3.f };
+    struct glug_vec2 about = { 1.f, -2.f };
     struct glug_vec2 exp = { -4.2f, -0.6f };
 
-    glug_vec2_reflect(&dst, &b);
+    glug_vec2_reflect(&dst, &v, &about);
     ASSERT_VEC2_EQUAL(&dst, &exp, 0.00001f);
 }
 
 static void test_refract(void)
 {
-    struct glug_vec2 dst = { 3.f, 3.f };
+    struct glug_vec2 dst;
+    struct glug_vec2 v = { 3.f, 3.f };
     struct glug_vec2 n = { 1.f, -2.f };
-    struct glug_vec2 exp = { 0.12967f, 4.24065f };
+    struct glug_vec2 exp = { 0.06483f, 2.12032f };
 
-    glug_vec2_refract(&dst, &n, 1.f, 2.f);
+    glug_vec2_refract(&dst, &v, &n, 1.f / 2.f);
     ASSERT_VEC2_EQUAL(&dst, &exp, 0.00001f);
 }
 
@@ -384,7 +399,7 @@ int main(void)
     ADD_TEST(vec2_suite, dist);
     ADD_TEST(vec2_suite, dist_sq);
     ADD_TEST(vec2_suite, dist_taxi);
-    ADD_TEST(vec2_suite, angle_to);
+    ADD_TEST(vec2_suite, angle_btw);
     ADD_TEST(vec2_suite, project);
     ADD_TEST(vec2_suite, reject);
     ADD_TEST(vec2_suite, reflect);


### PR DESCRIPTION
- separate input args from output args
- return `dst` arg to chain functions more easily
- remove vec2_t from includes of vec2.h